### PR TITLE
인코딩 이슈 디버그, 진행 상황 체크

### DIFF
--- a/NamuwikiExtractor.py
+++ b/NamuwikiExtractor.py
@@ -3,6 +3,7 @@ import ijson
 import kss
 import argparse
 from namuwiki.extractor import extract_text
+from tqdm import tqdm
 
 
 capture_values = [
@@ -26,8 +27,8 @@ def kss_sentence_seperator(file, text):
 def parse_namuwiki_json(path, limit=-1, debug=False):
   i = 0
   doc = {}
-  with open(path) as f:
-    for prefix, event, value in ijson.parse(f):
+  with open(path, encoding="utf-8") as f:
+    for prefix, event, value in tqdm(ijson.parse(f), desc="[Parsing]"):
 
       if debug:
         print(prefix, event, value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ijson
 kss
 namu-wiki-extractor
+tqdm


### PR DESCRIPTION
- 파일을 읽어들이는 과정에서 `unicodedecodeerror: 'cp949' codec can't decode byte 0xeb in position 46: illegal multibyte sequence` 에러 발생
- `tqdm` 라이브러리를 활용해 진행 상황 체크